### PR TITLE
fix(BuildGradle): #34699 Android Recording Crash Fixed

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -100,6 +100,7 @@ android {
     }
 
     namespace 'com.evilratt.flutter_zoom_sdk'
+    buildFeatures { dataBinding = true }
 }
 
 publishing {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -94,7 +94,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.0+108"
+    version: "1.2.0+109"
   js:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_zoom_sdk
 description: Zoom SDK from ZOOM ported to flutter as plugin with all necessary features and with Null Safety which is implementation by EvilRATT
-version: 1.2.0+108
+version: 1.2.0+109
 homepage: https://github.com/evilrat/flutter_zoom_sdk
 repository: https://github.com/evilrat/flutter_zoom_sdk
 issue_tracker: https://github.com/evilrat/flutter_zoom_sdk/issues


### PR DESCRIPTION
##What's changed

Previously this error is giving on logs "Landroidx/databinding/DataBinderMapperImpl" when host tries to record the meeting.
DataBinding enabled on build.gradle file.

##How to test

- Connect this branch to ProApp with downloading project and connecting as a path or connect via git branch
- Then Run ProApp
- Login ProApp via Android.
- Try to enter the meeting.
- Then Host starts the recording of the meeting.

Previously app is crashing and ProApp is closing.
Now it should continue on meeting.