### PR TITLE
feat(BuildGradle): #34726 Zoom SDK Warning Play Console

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -63,7 +63,6 @@ android {
         implementation "com.github.bumptech.glide:annotations:4.11.0"
         implementation "com.github.bumptech.glide:glide:4.11.0"
         annotationProcessor 'com.github.bumptech.glide:compiler:4.11.0'
-        implementation "org.greenrobot:eventbus:3.1.1"
 
         implementation "androidx.recyclerview:recyclerview:1.2.1"
         implementation "com.airbnb.android:lottie:4.0.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -94,7 +94,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.0+109"
+    version: "1.2.0+110"
   js:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_zoom_sdk
 description: Zoom SDK from ZOOM ported to flutter as plugin with all necessary features and with Null Safety which is implementation by EvilRATT
-version: 1.2.0+109
+version: 1.2.0+110
 homepage: https://github.com/evilrat/flutter_zoom_sdk
 repository: https://github.com/evilrat/flutter_zoom_sdk
 issue_tracker: https://github.com/evilrat/flutter_zoom_sdk/issues


### PR DESCRIPTION
### What's changed
In Android Zoom SDK EventBus dependency removed based on [this documentation](https://developers.zoom.us/changelog/meeting-sdk/android/6.0.10/).
Current Version is 6.0.12

###How to test

1. Connect this branch to ProApp.
2. Run on android device.
3. Try to attend meeting.
4. Try to record meeting on host side.
5. Everyting should works fine.


